### PR TITLE
update to latest sdk & fix file references

### DIFF
--- a/Demo/Messages Demo.xcodeproj/project.pbxproj
+++ b/Demo/Messages Demo.xcodeproj/project.pbxproj
@@ -21,18 +21,18 @@
 		B27D0FDE12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGray.png in Resources */ = {isa = PBXBuildFile; fileRef = B27D0FDA12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGray.png */; };
 		B27D0FDF12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGreen.png in Resources */ = {isa = PBXBuildFile; fileRef = B27D0FDB12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGreen.png */; };
 		B27D0FF012878B2200B58D1D /* SSToolkit.bundle in Resources */ = {isa = PBXBuildFile; fileRef = B27D0FEF12878B2200B58D1D /* SSToolkit.bundle */; };
-		B27D0FFA12878B2700B58D1D /* libTWToolkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B27D0FEE12878B1900B58D1D /* libTWToolkit.a */; };
+		C94A5254134B0730004C7881 /* libTWToolkit.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C94A5238134B05DB004C7881 /* libTWToolkit.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		B27D0FED12878B1900B58D1D /* PBXContainerItemProxy */ = {
+		C94A5237134B05DB004C7881 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = D2AAC07E0554694100DB518D;
 			remoteInfo = SSToolkit;
 		};
-		B27D0FFB12878B2D00B58D1D /* PBXContainerItemProxy */ = {
+		C94A524F134B06D3004C7881 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */;
 			proxyType = 1;
@@ -63,7 +63,7 @@
 		B27D0FD912878AAB00B58D1D /* SSMessagesViewControllerTextFieldBackground.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessagesViewControllerTextFieldBackground.png; sourceTree = "<group>"; };
 		B27D0FDA12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGray.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessageTableViewCellBackgroundGray.png; sourceTree = "<group>"; };
 		B27D0FDB12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGreen.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessageTableViewCellBackgroundGreen.png; sourceTree = "<group>"; };
-		B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SSToolkit.xcodeproj; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Demo/SSToolkit/SSToolkit.xcodeproj; sourceTree = "<group>"; };
+		B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SSToolkit.xcodeproj; path = ../SSToolkit/SSToolkit.xcodeproj; sourceTree = "<group>"; };
 		B27D0FEF12878B2200B58D1D /* SSToolkit.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SSToolkit.bundle; path = SSToolkit/Resources/SSToolkit.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -75,7 +75,7 @@
 				1D60589F0D05DD5A006BFB54 /* Foundation.framework in Frameworks */,
 				1DF5F4E00D08C38300B7A737 /* UIKit.framework in Frameworks */,
 				288765FD0DF74451002DB57D /* CoreGraphics.framework in Frameworks */,
-				B27D0FFA12878B2700B58D1D /* libTWToolkit.a in Frameworks */,
+				C94A5254134B0730004C7881 /* libTWToolkit.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -161,10 +161,10 @@
 			path = ../Images;
 			sourceTree = "<group>";
 		};
-		B27D0FEA12878B1900B58D1D /* Products */ = {
+		C94A5234134B05DB004C7881 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				B27D0FEE12878B1900B58D1D /* libTWToolkit.a */,
+				C94A5238134B05DB004C7881 /* libTWToolkit.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -183,7 +183,7 @@
 			buildRules = (
 			);
 			dependencies = (
-				B27D0FFC12878B2D00B58D1D /* PBXTargetDependency */,
+				C94A5250134B06D3004C7881 /* PBXTargetDependency */,
 			);
 			name = "Messages Demo";
 			productName = "Messages Demo";
@@ -209,7 +209,7 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = B27D0FEA12878B1900B58D1D /* Products */;
+					ProductGroup = C94A5234134B05DB004C7881 /* Products */;
 					ProjectRef = B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */;
 				},
 			);
@@ -221,11 +221,11 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		B27D0FEE12878B1900B58D1D /* libTWToolkit.a */ = {
+		C94A5238134B05DB004C7881 /* libTWToolkit.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
 			path = libTWToolkit.a;
-			remoteRef = B27D0FED12878B1900B58D1D /* PBXContainerItemProxy */;
+			remoteRef = C94A5237134B05DB004C7881 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -262,10 +262,10 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		B27D0FFC12878B2D00B58D1D /* PBXTargetDependency */ = {
+		C94A5250134B06D3004C7881 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = SSToolkit;
-			targetProxy = B27D0FFB12878B2D00B58D1D /* PBXContainerItemProxy */;
+			targetProxy = C94A524F134B06D3004C7881 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Demo/Messages Demo.xcodeproj/project.pbxproj
+++ b/Demo/Messages Demo.xcodeproj/project.pbxproj
@@ -29,14 +29,14 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */;
 			proxyType = 2;
-			remoteGlobalIDString = D2AAC07E0554694100DB518D /* libTWToolkit.a */;
+			remoteGlobalIDString = D2AAC07E0554694100DB518D;
 			remoteInfo = SSToolkit;
 		};
 		B27D0FFB12878B2D00B58D1D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */;
 			proxyType = 1;
-			remoteGlobalIDString = D2AAC07D0554694100DB518D /* SSToolkit */;
+			remoteGlobalIDString = D2AAC07D0554694100DB518D;
 			remoteInfo = SSToolkit;
 		};
 /* End PBXContainerItemProxy section */
@@ -53,12 +53,12 @@
 		8D1107310486CEB800E47090 /* Messages_Demo-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Messages_Demo-Info.plist"; plistStructureDefinitionIdentifier = "com.apple.xcode.plist.structure-definition.iphone.info-plist"; sourceTree = "<group>"; };
 		B27D0FC712878A3300B58D1D /* MDDemoViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MDDemoViewController.h; sourceTree = "<group>"; };
 		B27D0FC812878A3300B58D1D /* MDDemoViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MDDemoViewController.m; sourceTree = "<group>"; };
-		B27D0FCE12878AA300B58D1D /* SSMessagesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SSMessagesViewController.h; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Classes/SSMessagesViewController.h; sourceTree = "<group>"; };
-		B27D0FCF12878AA300B58D1D /* SSMessagesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SSMessagesViewController.m; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Classes/SSMessagesViewController.m; sourceTree = "<group>"; };
-		B27D0FD012878AA300B58D1D /* SSMessageTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SSMessageTableViewCell.h; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Classes/SSMessageTableViewCell.h; sourceTree = "<group>"; };
-		B27D0FD112878AA300B58D1D /* SSMessageTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SSMessageTableViewCell.m; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Classes/SSMessageTableViewCell.m; sourceTree = "<group>"; };
-		B27D0FD212878AA300B58D1D /* SSMessageTableViewCellBubbleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SSMessageTableViewCellBubbleView.h; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Classes/SSMessageTableViewCellBubbleView.h; sourceTree = "<group>"; };
-		B27D0FD312878AA300B58D1D /* SSMessageTableViewCellBubbleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SSMessageTableViewCellBubbleView.m; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Classes/SSMessageTableViewCellBubbleView.m; sourceTree = "<group>"; };
+		B27D0FCE12878AA300B58D1D /* SSMessagesViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SSMessagesViewController.h; path = ../../Classes/SSMessagesViewController.h; sourceTree = "<group>"; };
+		B27D0FCF12878AA300B58D1D /* SSMessagesViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SSMessagesViewController.m; path = ../../Classes/SSMessagesViewController.m; sourceTree = "<group>"; };
+		B27D0FD012878AA300B58D1D /* SSMessageTableViewCell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SSMessageTableViewCell.h; path = ../../Classes/SSMessageTableViewCell.h; sourceTree = "<group>"; };
+		B27D0FD112878AA300B58D1D /* SSMessageTableViewCell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SSMessageTableViewCell.m; path = ../../Classes/SSMessageTableViewCell.m; sourceTree = "<group>"; };
+		B27D0FD212878AA300B58D1D /* SSMessageTableViewCellBubbleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SSMessageTableViewCellBubbleView.h; path = ../../Classes/SSMessageTableViewCellBubbleView.h; sourceTree = "<group>"; };
+		B27D0FD312878AA300B58D1D /* SSMessageTableViewCellBubbleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SSMessageTableViewCellBubbleView.m; path = ../../Classes/SSMessageTableViewCellBubbleView.m; sourceTree = "<group>"; };
 		B27D0FD812878AAB00B58D1D /* SSMessagesViewControllerSendButtonBackground.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessagesViewControllerSendButtonBackground.png; sourceTree = "<group>"; };
 		B27D0FD912878AAB00B58D1D /* SSMessagesViewControllerTextFieldBackground.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessagesViewControllerTextFieldBackground.png; sourceTree = "<group>"; };
 		B27D0FDA12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGray.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessageTableViewCellBackgroundGray.png; sourceTree = "<group>"; };
@@ -158,7 +158,7 @@
 				B27D0FDB12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGreen.png */,
 			);
 			name = Images;
-			path = ../../../../Code/samsoffes/ssmessagesviewcontroller/Images;
+			path = ../Images;
 			sourceTree = "<group>";
 		};
 		B27D0FEA12878B1900B58D1D /* Products */ = {

--- a/Demo/Messages Demo.xcodeproj/project.pbxproj
+++ b/Demo/Messages Demo.xcodeproj/project.pbxproj
@@ -64,7 +64,7 @@
 		B27D0FDA12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGray.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessageTableViewCellBackgroundGray.png; sourceTree = "<group>"; };
 		B27D0FDB12878AAB00B58D1D /* SSMessageTableViewCellBackgroundGreen.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = SSMessageTableViewCellBackgroundGreen.png; sourceTree = "<group>"; };
 		B27D0FE412878B1900B58D1D /* SSToolkit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SSToolkit.xcodeproj; path = ../../../../../Code/samsoffes/ssmessagesviewcontroller/Demo/SSToolkit/SSToolkit.xcodeproj; sourceTree = "<group>"; };
-		B27D0FEF12878B2200B58D1D /* SSToolkit.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SSToolkit.bundle; path = ../../../../Code/samsoffes/ssmessagesviewcontroller/Demo/SSToolkit/Resources/SSToolkit.bundle; sourceTree = "<group>"; };
+		B27D0FEF12878B2200B58D1D /* SSToolkit.bundle */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.plug-in"; name = SSToolkit.bundle; path = SSToolkit/Resources/SSToolkit.bundle; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */


### PR DESCRIPTION
Hi Sam! :)

I just built [acaniChat](https://github.com/acani/acaniChat), and then I found this!

I tried cloning, readme should say `git submodule update --init`.

Also, I fixed the references on some of the files that were relative to like your home dir or something, so they weren't found initially on my comp.

It should now build immediately for everyone.

Also, creating a chat view like this is still a noble act even though MessageUI is out. Because what about apps like Twitter or Facebook or Grindr that have their own chat views? So many apps do now. An open source project like this offers a lot to those apps that want to use their own messaging services (vs SMS).

Check out acaniChat if you get a chance. It uses Core Data with NSFetchedResultsController and the inputView is a UITextView that expands and scrolls after 4 lines of expanding. It's pretty cool. It also autorotates.

However, it's buggy right now, and your code is SOO nice... acaniChat is all one big file. Someday, I think I'll write code more organized like you do. Any feedback or contribute is welcome!

Thanks!

Matt
